### PR TITLE
added the old owner back to the license file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,7 @@
 MIT License
 
+Copyright (c) 2014-2016 Yanis Wang &lt;yanis.wang@gmail.com&gt;
+
 Copyright (c) 2018 David Dias (Thanks to the initial contributor Yanis Wan)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:

You can list several copyrights in the license file in chronological order

Example: https://github.com/salsita/node-pg-migrate/blob/master/LICENSE

#### Proposed changes:

- added the old owner back to the license file