### PR TITLE
remove base resolve

### DIFF
--- a/bin/htmlhint
+++ b/bin/htmlhint
@@ -268,7 +268,6 @@ function getGlobInfo(target){
     var globInfo = parseGlob(target);
     var base = path.resolve(globInfo.base);
     base += /\/$/.test(base) ? '' : '/';
-    base = path.resolve(base);
     var pattern = globInfo.glob;
     var globPath = globInfo.path;
     var defaultGlob = '*.{htm,html}';


### PR DESCRIPTION
**Fixes**: #247 

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:

The previous fix has broken the use of HTMLHint on Mac OSX.

#### Proposed changes:

- The duplication of path.resolve broked the correct path.
