### PR TITLE
remove all license headers from code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,7 +48,6 @@ module.exports = function(grunt) {
         uglify: {
             htmlhint: {
                 options: {
-                    banner: "/*!\r\n * HTMLHint v<%= pkg.version %>\r\n * https://github.com/yaniswang/HTMLHint\r\n *\r\n * (c) 2014-"+new Date().getFullYear()+" Yanis Wang <yanis.wang@gmail.com>.\r\n * MIT Licensed\r\n */\n",
                     beautify: {
                         ascii_only: true
                     }

--- a/bin/formatters/checkstyle.js
+++ b/bin/formatters/checkstyle.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 var xml = require('xml');
 
 var checkstyleFormatter = function(formatter){

--- a/bin/formatters/compact.js
+++ b/bin/formatters/compact.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 var compactFormatter = function(formatter, HTMLHint, options){
     var nocolor = options.nocolor;
     formatter.on('file', function(event){

--- a/bin/formatters/default.js
+++ b/bin/formatters/default.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 var defaultFormatter = function(formatter, HTMLHint, options){
     var nocolor = options.nocolor;
     formatter.on('start', function(){

--- a/bin/formatters/json.js
+++ b/bin/formatters/json.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 var jsonFormatter = function(formatter){
     formatter.on('end', function(event){
         console.log(JSON.stringify(event.arrAllMessages));

--- a/bin/formatters/junit.js
+++ b/bin/formatters/junit.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 var xml = require('xml');
 
 var junitFormatter = function(formatter, HTMLHint){

--- a/bin/formatters/markdown.js
+++ b/bin/formatters/markdown.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 var markdownFormatter = function(formatter, HTMLHint){
     formatter.on('end', function(event){
         console.log('# TOC');

--- a/bin/formatters/unix.js
+++ b/bin/formatters/unix.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 var unixFormatter = function(formatter, HTMLHint, options){
     var nocolor = options.nocolor;
     formatter.on('file', function(event){

--- a/src/core.js
+++ b/src/core.js
@@ -1,8 +1,4 @@
 /* jshint -W079 */
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 var HTMLHint = (function (undefined) {
 
     var HTMLHint = {};

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -1,8 +1,4 @@
 /* jshint -W079 */
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 var HTMLParser = (function(undefined){
 
     var HTMLParser = function(){

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 (function(HTMLHint, undefined){
 
     var Reporter = function(){

--- a/src/rules/alt-require.js
+++ b/src/rules/alt-require.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * Copyright (c) 2014, Takeshi Kurosawa <taken.spc@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'alt-require',
     description: 'The alt attribute of an <img> element must be present and alt attribute of area[href] and input[type=image] must have a value.',

--- a/src/rules/attr-lowercase.js
+++ b/src/rules/attr-lowercase.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'attr-lowercase',
     description: 'All attribute names must be in lowercase.',

--- a/src/rules/attr-no-duplication.js
+++ b/src/rules/attr-no-duplication.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2014, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'attr-no-duplication',
     description: 'Elements cannot have duplicate attributes.',

--- a/src/rules/attr-unsafe-chars.js
+++ b/src/rules/attr-unsafe-chars.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2014, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'attr-unsafe-chars',
     description: 'Attribute values cannot contain unsafe chars.',

--- a/src/rules/attr-value-double-quotes.js
+++ b/src/rules/attr-value-double-quotes.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'attr-value-double-quotes',
     description: 'Attribute values must be in double quotes.',

--- a/src/rules/attr-value-not-empty.js
+++ b/src/rules/attr-value-not-empty.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'attr-value-not-empty',
     description: 'All attributes must have values.',

--- a/src/rules/csslint.js
+++ b/src/rules/csslint.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'csslint',
     description: 'Scan css with csslint.',

--- a/src/rules/doctype-first.js
+++ b/src/rules/doctype-first.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'doctype-first',
     description: 'Doctype must be declared first.',

--- a/src/rules/doctype-html5.js
+++ b/src/rules/doctype-html5.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'doctype-html5',
     description: 'Invalid doctype. Use: "<!DOCTYPE html>"',

--- a/src/rules/head-script-disabled.js
+++ b/src/rules/head-script-disabled.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'head-script-disabled',
     description: 'The <script> tag cannot be used in a <head> tag.',

--- a/src/rules/href-abs-or-rel.js
+++ b/src/rules/href-abs-or-rel.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2014, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'href-abs-or-rel',
     description: 'An href attribute must be either absolute or relative.',

--- a/src/rules/id-class-ad-disabled.js
+++ b/src/rules/id-class-ad-disabled.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2014, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'id-class-ad-disabled',
     description: 'The id and class attributes cannot use the ad keyword, it will be blocked by adblock software.',

--- a/src/rules/id-class-value.js
+++ b/src/rules/id-class-value.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'id-class-value',
     description: 'The id and class attribute values must meet the specified rules.',

--- a/src/rules/id-unique.js
+++ b/src/rules/id-unique.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'id-unique',
     description: 'The value of id attributes must be unique.',

--- a/src/rules/inline-script-disabled.js
+++ b/src/rules/inline-script-disabled.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'inline-script-disabled',
     description: 'Inline script cannot be used.',

--- a/src/rules/inline-style-disabled.js
+++ b/src/rules/inline-style-disabled.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'inline-style-disabled',
     description: 'Inline style cannot be used.',

--- a/src/rules/jshint.js
+++ b/src/rules/jshint.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'jshint',
     description: 'Scan script with jshint.',

--- a/src/rules/space-tab-mixed-disabled.js
+++ b/src/rules/space-tab-mixed-disabled.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2014, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'space-tab-mixed-disabled',
     description: 'Do not mix tabs and spaces for indentation.',

--- a/src/rules/spec-char-escape.js
+++ b/src/rules/spec-char-escape.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'spec-char-escape',
     description: 'Special characters must be escaped.',

--- a/src/rules/src-not-empty.js
+++ b/src/rules/src-not-empty.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'src-not-empty',
     description: 'The src attribute of an img(script,link) must have a value.',

--- a/src/rules/style-disabled.js
+++ b/src/rules/style-disabled.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'style-disabled',
     description: '<style> tags cannot be used.',

--- a/src/rules/tag-pair.js
+++ b/src/rules/tag-pair.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'tag-pair',
     description: 'Tag must be paired.',

--- a/src/rules/tag-self-close.js
+++ b/src/rules/tag-self-close.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'tag-self-close',
     description: 'Empty tags must be self closed.',

--- a/src/rules/tagname-lowercase.js
+++ b/src/rules/tagname-lowercase.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'tagname-lowercase',
     description: 'All html element names must be in lowercase.',

--- a/src/rules/title-require.js
+++ b/src/rules/title-require.js
@@ -1,7 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
 HTMLHint.addRule({
     id: 'title-require',
     description: '<title> must be present in <head> tag.',

--- a/test/core-spec.js
+++ b/test/core-spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2014, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../index").HTMLHint;

--- a/test/htmlparser.spec.js
+++ b/test/htmlparser.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLParser  = require("../index").HTMLParser;

--- a/test/rules/alt-require.spec.js
+++ b/test/rules/alt-require.spec.js
@@ -1,9 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * Copyright (c) 2014, Takeshi Kurosawa <taken.spc@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/attr-lowercase.spec.js
+++ b/test/rules/attr-lowercase.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/attr-no-duplication.spec.js
+++ b/test/rules/attr-no-duplication.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2014, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/attr-unsafe-chars.spec.js
+++ b/test/rules/attr-unsafe-chars.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/attr-value-double-quotes.spec.js
+++ b/test/rules/attr-value-double-quotes.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/attr-value-not-empty.spec.js
+++ b/test/rules/attr-value-not-empty.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/csslint.spec.js
+++ b/test/rules/csslint.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/default.spec.js
+++ b/test/rules/default.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/doctype-first.spec.js
+++ b/test/rules/doctype-first.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/doctype-html5.spec.js
+++ b/test/rules/doctype-html5.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/head-require.spec.js
+++ b/test/rules/head-require.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/head-script-disabled.spec.js
+++ b/test/rules/head-script-disabled.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/href-abs-or-rel.spec.js
+++ b/test/rules/href-abs-or-rel.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2014, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/id-class-ad-disabled.spec.js
+++ b/test/rules/id-class-ad-disabled.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2014, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/id-class-value.spec.js
+++ b/test/rules/id-class-value.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/id-unique.spec.js
+++ b/test/rules/id-unique.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/inline-script-disabled.spec.js
+++ b/test/rules/inline-script-disabled.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/inline-style-disabled.spec.js
+++ b/test/rules/inline-style-disabled.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/jshint.spec.js
+++ b/test/rules/jshint.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/space-tab-mixed-disabled.spec.js
+++ b/test/rules/space-tab-mixed-disabled.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2014-2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/spec-char-escape.spec.js
+++ b/test/rules/spec-char-escape.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/src-not-empty.spec.js
+++ b/test/rules/src-not-empty.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/style-disabled.spec.js
+++ b/test/rules/style-disabled.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/tag-pair.spec.js
+++ b/test/rules/tag-pair.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/tag-self-close.spec.js
+++ b/test/rules/tag-self-close.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/tagname-lowercase.spec.js
+++ b/test/rules/tagname-lowercase.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;

--- a/test/rules/title-require.spec.js
+++ b/test/rules/title-require.spec.js
@@ -1,8 +1,3 @@
-/**
- * Copyright (c) 2015, Yanis Wang <yanis.wang@gmail.com>
- * MIT Licensed
- */
-
 var expect  = require("expect.js");
 
 var HTMLHint  = require("../../index").HTMLHint;


### PR DESCRIPTION
**Fixes**: #271 

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:

The license texts are redundant and do not add value to an MIT license
In addition, the main author and contributors can be found in the `package.json` and others in the `README.md`

#### Proposed changes:

- remove all header license texts