### PR TITLE
fix: update the check for root htmlhintrc

### DIFF
--- a/bin/htmlhint
+++ b/bin/htmlhint
@@ -302,11 +302,12 @@ function getConfig(configPath, base, formatter){
             base = path.dirname(base);
         }
         while(base){
-            var tmpConfigFile = path.resolve(base+path.sep, '.htmlhintrc');
+            var tmpConfigFile = path.resolve(base, '.htmlhintrc');
             if(fs.existsSync(tmpConfigFile)){
                 configPath = tmpConfigFile;
                 break;
             }
+            if (!base) {break;}
             base = base.substring(0,base.lastIndexOf(path.sep));
         }
     }


### PR DESCRIPTION
**Fixes**: #163 and #181

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:

The fix was originally suggested by @phaux and make HTMLHint checking the root for the config file. 

#### Proposed changes:

- Change the tmpConfigFilve variable.
- Force the console to "break" if base is not found.
